### PR TITLE
ci: fix docs.yml environment gate + tune dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,22 +42,34 @@ updates:
       - "dependencies"
       - "javascript"
 
-  # GitHub Actions workflows
+  # GitHub Actions workflows — grouped into a single PR per update cycle so
+  # a fresh dependabot.yml doesn't open a flood of one-action-per-PR noise.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     commit-message:
       prefix: "chore(ci)"
     labels:
       - "dependencies"
       - "ci"
 
-  # Docker base images
+  # Docker base images. Major-version bumps (e.g. a new Python minor/major
+  # release like 3.11 -> 3.14) are intentionally excluded: those need a
+  # manual compatibility check (native deps, wheel availability) rather than
+  # an auto-generated PR. Patch/minor updates on the pinned line still flow
+  # through normally.
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "python"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
     commit-message:
       prefix: "chore(docker)"
     labels:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,18 +17,15 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: docs-pages
   cancel-in-progress: true
 
 jobs:
-  build-and-publish:
+  build:
+    name: Build
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -50,16 +47,29 @@ jobs:
           NODE_PATH: ${{ github.workspace }}/node_modules
 
       - name: Ensure .nojekyll
-        if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: touch docs/_book/.nojekyll
 
+      # Uploading the Pages artifact does not require the `github-pages`
+      # deployment environment — only the actual deploy step below does.
+      # Keeping this in the build job means PRs get a build/lint signal
+      # without needing environment approval or protected-branch access.
       - name: Upload Pages artifact
-        if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: actions/upload-pages-artifact@v5
         with:
           path: docs/_book
 
+  deploy:
+    name: Deploy
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
       - name: Deploy to GitHub Pages
-        if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -16,14 +16,14 @@ jobs:
     steps:
       - uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: >
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: >
             👋 Thanks for opening your first issue in AgentGuard! A maintainer
             will take a look soon. In the meantime, please make sure you've
             included enough detail to reproduce the problem (see the issue
             template checklist) — see [CONTRIBUTING.md](https://github.com/WhitzardAgent/AgentGuard/blob/main/CONTRIBUTING.md)
             for more on how the project is organized.
-          pr-message: >
+          pr_message: >
             🎉 Thanks for your first pull request to AgentGuard! A maintainer
             will review it soon. While you wait, please double-check the PR
             checklist and make sure `ruff check src tests`, `pytest -q`, and


### PR DESCRIPTION
## Summary

This PR fixes two issues found after the previous CI and governance updates:

1. **Docs workflow failure on pull requests**
   The docs workflow used the `github-pages` environment at the job level, which caused non-main branches to fail immediately because of environment protection rules.
   The workflow is now split into:

   * `build`: runs for all events and checks that the documentation builds correctly.
   * `deploy`: runs only on pushes to `main` or manual runs, and deploys after the build succeeds.

2. **Too many Dependabot pull requests**
   GitHub Actions updates are now grouped into one pull request.
   Major and minor Docker image updates are ignored because they may require manual compatibility checks.

This branch is based on the latest `main` and includes the recent GitHub Actions version updates. The workflow and Dependabot configuration have also been checked.
